### PR TITLE
Feature/native socket improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>sonar-jacoco-listeners</artifactId>
-            <version>5.0.1.12818</version>
+            <version>3.14</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/mjd/nativesocket/NativeSocket.java
+++ b/src/main/java/org/mjd/nativesocket/NativeSocket.java
@@ -11,29 +11,23 @@ public interface NativeSocket
 {
     /**
      * Enables the keep alive mechanism on this {@link NativeSocket} with the given interval.
-     * The keep alive interval is the interval between sequential keep alive probes, regardless of
-     * what the connection has exchanged in the meantime
-     * <p>
-     * Note, this enables keep alive on this socket if not already enabled.
-     *
-     * @param interval
-     *            keep alive interval
-     */
-    void setKeepAliveInterval(TimeDuration interval);
-
-    /**
-     * Enables the keep alive mechanism on this {@link NativeSocket} with the given idle time.
      * The keep alive idle time is the  interval between the last data packet sent (simple ACKs
      * are not considered data) and the first keep alive probe; after the connection is
      * marked to need keep alive, this counter is not used any further.
      * <p>
+     * The keep alive interval is the interval between sequential keep alive probes, regardless of
+     * what the connection has exchanged in the meantime
+     * <p>
+     * The keep alive probes is the number of unsuccessful keep alive probes after which a
+     * connection is considered dead.
+     * <p>
      * Note, this enables keep alive on this socket if not already enabled.
      *
-     * @param idleTime
-     *            keep time interval
+     * @param idleTime keep alive idle time
+     * @param interval keep alive interval
+     * @param probes keep alive probes
      */
-    void setKeepAliveIdle(TimeDuration idleTime);
-
+    void setKeepAlive(TimeDuration idleTime, TimeDuration interval, TimeDuration probes);
 
     /**
      * Data class for keep alive information specific to a {@link NativeSocket}

--- a/src/main/java/org/mjd/nativesocket/factories/posix/PosixNativeSocketFactory.java
+++ b/src/main/java/org/mjd/nativesocket/factories/posix/PosixNativeSocketFactory.java
@@ -26,7 +26,7 @@ public class PosixNativeSocketFactory implements NativeSocketFactory
     @Override
     public NativeSocket createFrom(SocketChannel socketChannel)
     {
-        return new PosixSocket(socketChannel.socket(), StandardLibStaticFactory.getStandardLib(),
+        return new PosixSocket(socketChannel, StandardLibStaticFactory.getStandardLib(),
                                new LinuxJdkFileDescriptorAccessor());
     }
 }

--- a/src/main/java/org/mjd/nativesocket/internal/fd/FileDescriptorAccessor.java
+++ b/src/main/java/org/mjd/nativesocket/internal/fd/FileDescriptorAccessor.java
@@ -1,6 +1,7 @@
 package org.mjd.nativesocket.internal.fd;
 
 import java.net.Socket;
+import java.nio.channels.SocketChannel;
 
 /**
  * File Descriptor accessor class.
@@ -24,8 +25,16 @@ public interface FileDescriptorAccessor
     /**
      * Extracts the underlying file descriptor for a {@link Socket}
      * @param socket the {@link Socket} to extract the file descriptor for.
-     * @return the int representation of the file descriptor
+     * @return the long representation of the file descriptor
      * @throws FileDescriptorException
      */
     long extractFileDescriptor(Socket socket) throws FileDescriptorException;
+
+    /**
+     * Extracts the underlying file descriptor for a {@link SocketChannel}
+     * @param socketChannel the {@link SocketChannel} to extract the file descriptor for.
+     * @return the long representation of the file descriptor
+     * @throws FileDescriptorException
+     */
+    long extractFileDescriptor(SocketChannel socketChannel) throws FileDescriptorException;
 }

--- a/src/main/java/org/mjd/nativesocket/internal/fd/jdk/JdkFileDescriptorAccessor.java
+++ b/src/main/java/org/mjd/nativesocket/internal/fd/jdk/JdkFileDescriptorAccessor.java
@@ -1,10 +1,12 @@
 package org.mjd.nativesocket.internal.fd.jdk;
 
 import java.io.FileDescriptor;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.Socket;
 import java.net.SocketImpl;
+import java.nio.channels.SocketChannel;
 
 /**
  * JDK Specific class for extracting {@link FileDescriptor} instances from various abstractions such as {@link Socket}
@@ -38,6 +40,17 @@ public final class JdkFileDescriptorAccessor
         private SocketImplData() { }
     }
 
+    protected static final class SocketChannelImplData
+    {
+        /** Implementation class used to get the {@link FileDescriptor} */
+        public static final String GET_SOCKETCHANNEL_IMPL_CLASS = "sun.nio.ch.SocketChannelImpl";
+        /** Field name used to get the declared field from the implementation class */
+        public static final String GET_FD_FIELD_NAME = "fd";
+
+        /** Data class */
+        private SocketChannelImplData() { }
+    }
+
 
     /**
      * Discovers and returns the Java {@link FileDescriptor} from a {@link Socket}
@@ -63,6 +76,30 @@ public final class JdkFileDescriptorAccessor
 
         SocketImpl impl = (SocketImpl) getImpl.invoke(socket);
         return (FileDescriptor) getFileDescriptor.invoke(impl);
+    }
+
+    /**
+     * Discovers and returns the Java {@link FileDescriptor} from a {@link SocketChannel}
+     *
+     * @param socketChannel
+     *            the {@link SocketChannel} to get the {@link FileDescriptor} for.
+     * @return the {@link FileDescriptor} of the {@link SocketChannel} socket
+     * @throws ClassNotFoundException
+     *             if the {@link FileDescriptor} cannot be retrieved
+     * @throws NoSuchFieldException
+     *             if the {@link FileDescriptor} cannot be retrieved
+     * @throws IllegalAccessException
+     *             if the {@link FileDescriptor} cannot be retrieved
+     */
+    public static FileDescriptor getJavaFileDescriptor(SocketChannel socketChannel) throws ClassNotFoundException,
+                                                                                       NoSuchFieldException,
+                                                                                       IllegalAccessException
+    {
+        Class<?> socketChannelImpl = Class.forName(SocketChannelImplData.GET_SOCKETCHANNEL_IMPL_CLASS);
+        Field socketChannelFd = socketChannelImpl.getDeclaredField(SocketChannelImplData.GET_FD_FIELD_NAME);
+        socketChannelFd.setAccessible(true);
+
+        return (FileDescriptor) socketChannelFd.get(socketChannel);
     }
 
 }

--- a/src/main/java/org/mjd/nativesocket/internal/fd/linux/LinuxJdkFileDescriptorAccessor.java
+++ b/src/main/java/org/mjd/nativesocket/internal/fd/linux/LinuxJdkFileDescriptorAccessor.java
@@ -2,6 +2,7 @@ package org.mjd.nativesocket.internal.fd.linux;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.Socket;
+import java.nio.channels.SocketChannel;
 
 import org.mjd.nativesocket.internal.fd.FileDescriptorAccessor;
 
@@ -26,6 +27,20 @@ public final class LinuxJdkFileDescriptorAccessor implements FileDescriptorAcces
         }
         catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
                | InvocationTargetException e)
+        {
+            throw new FileDescriptorException(e);
+        }
+    }
+
+    @SuppressWarnings("restriction")
+    @Override
+    public long extractFileDescriptor(SocketChannel socketChannel) throws FileDescriptorException {
+        try
+        {
+            return getJavaIOFileDescriptorAccess().get(getJavaFileDescriptor(socketChannel));
+        }
+        catch (ClassNotFoundException | NoSuchFieldException | SecurityException | IllegalAccessException
+                | IllegalArgumentException e)
         {
             throw new FileDescriptorException(e);
         }

--- a/src/main/java/org/mjd/nativesocket/internal/fd/win/WinJdkFileDescriptorAccessor.java
+++ b/src/main/java/org/mjd/nativesocket/internal/fd/win/WinJdkFileDescriptorAccessor.java
@@ -2,6 +2,7 @@ package org.mjd.nativesocket.internal.fd.win;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.Socket;
+import java.nio.channels.SocketChannel;
 
 import org.mjd.nativesocket.internal.fd.FileDescriptorAccessor;
 
@@ -26,6 +27,20 @@ public final class WinJdkFileDescriptorAccessor implements FileDescriptorAccesso
         }
         catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
                | InvocationTargetException e)
+        {
+            throw new FileDescriptorException(e);
+        }
+    }
+
+    @SuppressWarnings("restriction")
+    @Override
+    public long extractFileDescriptor(SocketChannel socketChannel) throws FileDescriptorException {
+        try
+        {
+            return getJavaIOFileDescriptorAccess().getHandle(getJavaFileDescriptor(socketChannel));
+        }
+        catch (ClassNotFoundException | NoSuchFieldException | SecurityException | IllegalAccessException
+                | IllegalArgumentException e)
         {
             throw new FileDescriptorException(e);
         }

--- a/src/main/java/org/mjd/nativesocket/internal/sockets/posix/PosixSocket.java
+++ b/src/main/java/org/mjd/nativesocket/internal/sockets/posix/PosixSocket.java
@@ -68,20 +68,15 @@ public final class PosixSocket implements NativeSocket
     }
 
     @Override
-    public void setKeepAliveInterval(TimeDuration interval)
-    {
+    public void setKeepAlive(TimeDuration idleTime, TimeDuration interval, TimeDuration probes) {
+        IntByReference newTime = new IntByReference(Ints.checkedCast(idleTime.getStandardSeconds()));
         IntByReference newInterval = new IntByReference(Ints.checkedCast(interval.getStandardSeconds()));
-        enableKeepAlive();
-        socketCall(sockLib.setsockopt(fd, SOL_TCP, TCP_KEEPINTVL, newInterval.getPointer(), Ints.BYTES));
-    }
+        IntByReference newProbes = new IntByReference(Ints.checkedCast(probes.getStandardSeconds()));
 
-
-    @Override
-    public void setKeepAliveIdle(TimeDuration idletime)
-    {
-        IntByReference newTime = new IntByReference(Ints.checkedCast(idletime.getStandardSeconds()));
         enableKeepAlive();
         socketCall(sockLib.setsockopt(fd, SOL_TCP, TCP_KEEPIDLE, newTime.getPointer(), Ints.BYTES));
+        socketCall(sockLib.setsockopt(fd, SOL_TCP, TCP_KEEPINTVL, newInterval.getPointer(), Ints.BYTES));
+        socketCall(sockLib.setsockopt(fd, SOL_TCP, TCP_KEEPCNT, newProbes.getPointer(), Ints.BYTES));
     }
 
     @Override

--- a/src/main/java/org/mjd/nativesocket/internal/sockets/posix/PosixSocket.java
+++ b/src/main/java/org/mjd/nativesocket/internal/sockets/posix/PosixSocket.java
@@ -1,6 +1,7 @@
 package org.mjd.nativesocket.internal.sockets.posix;
 
 import java.net.Socket;
+import java.nio.channels.SocketChannel;
 
 import com.google.common.primitives.Ints;
 import com.sun.jna.Native;
@@ -60,6 +61,38 @@ public final class PosixSocket implements NativeSocket
         {
             sockLib = stdLib.loadStandardLibrary(PosixSocketLibrary.class);
             fd = Ints.checkedCast(fdAccessor.extractFileDescriptor(socket));
+        }
+        catch (FileDescriptorException e)
+        {
+            throw new IllegalStateException("The file descriptor cannot be determined for the given socket", e);
+        }
+    }
+
+    /**
+     * Do not use this directly, instead use the {@link NativeSocketStaticFactory}
+     *
+     * Constructs a {@link NativeSocket} for a Linux system, fully initialised and ready to use.
+     *
+     * <p>
+     * Requires the standard C library and sys/socket.h
+     *
+     * @param socketChannel
+     *            the socketChannel to wrap by this {@link NativeSocket}
+     * @param standardLib
+     *            strategy used to load the OS specific standard library.
+     * @param fileDescriptorAccessor
+     *            strategy used to extract file descriptor.
+     *
+     * @see NativeSocket
+     */
+    public PosixSocket(final SocketChannel socketChannel, StandardLib standardLib, FileDescriptorAccessor fileDescriptorAccessor)
+    {
+        this.stdLib = standardLib;
+        this.fdAccessor = fileDescriptorAccessor;
+        try
+        {
+            sockLib = stdLib.loadStandardLibrary(PosixSocketLibrary.class);
+            fd = Ints.checkedCast(fdAccessor.extractFileDescriptor(socketChannel));
         }
         catch (FileDescriptorException e)
         {

--- a/src/main/java/org/mjd/nativesocket/staticfactories/NativeSocketStaticFactory.java
+++ b/src/main/java/org/mjd/nativesocket/staticfactories/NativeSocketStaticFactory.java
@@ -52,10 +52,16 @@ public final class NativeSocketStaticFactory
      *            the Java {@link SocketChannel} to create a Native socket from
      * @return new {@link NativeSocket} for this Platform
      * @see NativeSocket
-     * @see Socket
+     * @see SocketChannel
      */
     public static NativeSocket createFrom(SocketChannel socketChannel)
     {
-        return createFrom(socketChannel.socket());
+        if (isPlatformPosixCompliant())
+        {
+            return new PosixSocket(socketChannel, StandardLibStaticFactory.getStandardLib(),
+                    new LinuxJdkFileDescriptorAccessor());
+        }
+        throw new IllegalStateException("No Native socket implementation for this platform: " +
+                System.getProperty("os.name"));
     }
 }

--- a/src/test/java/org/mjd/nativesocket/factories/natsock/NativeSocketStaticFactoryTest.java
+++ b/src/test/java/org/mjd/nativesocket/factories/natsock/NativeSocketStaticFactoryTest.java
@@ -1,8 +1,13 @@
 package org.mjd.nativesocket.factories.natsock;
 
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mjd.nativesocket.NativeSocket;
@@ -10,14 +15,23 @@ import org.mjd.nativesocket.staticfactories.NativeSocketStaticFactory;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.when;
-
 
 @RunWith(MockitoJUnitRunner.class)
 public class NativeSocketStaticFactoryTest
 {
+    private SocketChannel socketChannel;
+    private ServerSocketChannel server;
+
     @Mock private Socket mockSocket;
-    @Mock private SocketChannel mockSocketChannel;
+
+    @Before
+    public void setupPerTest() throws Exception
+    {
+        final InetSocketAddress serverAddress = new InetSocketAddress(InetAddress.getLocalHost(), 0);
+        server = ServerSocketChannel.open().bind(serverAddress);
+        final int serverPort = server.socket().getLocalPort();
+        socketChannel = SocketChannel.open(new InetSocketAddress(server.socket().getInetAddress(), serverPort));
+    }
 
     @Test
     public void testCreateFromSocketOnThisSystem()
@@ -26,10 +40,9 @@ public class NativeSocketStaticFactoryTest
     }
 
     @Test
-    public void testCreateFromSocketChannelOnThisSystem()
+    public void testCreateFromSocketChannelOnThisSystem() throws IOException
     {
-        when(mockSocketChannel.socket()).thenReturn(mockSocket);
-        NativeSocket nativeSocket = NativeSocketStaticFactory.createFrom(mockSocketChannel);
+        NativeSocket nativeSocket = NativeSocketStaticFactory.createFrom(socketChannel);
     }
 
 }

--- a/src/test/java/org/mjd/nativesocket/factories/natsock/NativeSocketStaticFactoryTest.java
+++ b/src/test/java/org/mjd/nativesocket/factories/natsock/NativeSocketStaticFactoryTest.java
@@ -40,7 +40,7 @@ public class NativeSocketStaticFactoryTest
     }
 
     @Test
-    public void testCreateFromSocketChannelOnThisSystem() throws IOException
+    public void testCreateFromSocketChannelOnThisSystem()
     {
         NativeSocket nativeSocket = NativeSocketStaticFactory.createFrom(socketChannel);
     }

--- a/src/test/java/org/mjd/nativesocket/factories/natsock/PosixNativeSocketFactoryTest.java
+++ b/src/test/java/org/mjd/nativesocket/factories/natsock/PosixNativeSocketFactoryTest.java
@@ -1,6 +1,9 @@
 package org.mjd.nativesocket.factories.natsock;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
 import org.junit.Before;
@@ -15,7 +18,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link PosixNativeSocketFactory}
@@ -23,17 +25,21 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public final class PosixNativeSocketFactoryTest
 {
-    @Mock private Socket mockSocket;
-    @Mock private SocketChannel mockSocketChannel;
+    private SocketChannel socketChannel;
+    private ServerSocketChannel server;
 
     private PosixNativeSocketFactory factoryUnderTest = new PosixNativeSocketFactory();
 
-    @Before
-    public void setupPerTest()
-    {
-        when(mockSocketChannel.socket()).thenReturn(mockSocket);
-    }
+    @Mock private Socket mockSocket;
 
+    @Before
+    public void setupPerTest() throws Exception
+    {
+        final InetSocketAddress serverAddress = new InetSocketAddress(InetAddress.getLocalHost(), 0);
+        server = ServerSocketChannel.open().bind(serverAddress);
+        final int serverPort = server.socket().getLocalPort();
+        socketChannel = SocketChannel.open(new InetSocketAddress(server.socket().getInetAddress(), serverPort));
+    }
 
     /**
      * Test that the {@link PosixNativeSocketFactory} creates the correct type of {@link NativeSocket}
@@ -49,7 +55,7 @@ public final class PosixNativeSocketFactoryTest
     @Test
     public void testFactoryCreatesTheCorrectTypeFromSocketChannel()
     {
-        NativeSocket nativeSocket = factoryUnderTest.createFrom(mockSocketChannel);
+        NativeSocket nativeSocket = factoryUnderTest.createFrom(socketChannel);
         assertThat(nativeSocket, is(instanceOf(PosixSocket.class)));
     }
 }

--- a/src/test/java/org/mjd/nativesocket/internal/PosixSocketOnLinuxTest.java
+++ b/src/test/java/org/mjd/nativesocket/internal/PosixSocketOnLinuxTest.java
@@ -90,24 +90,31 @@ public class PosixSocketOnLinuxTest
     }
 
     /**
-     * Tests we can set the keep alive with a duration on an IO {@link Socket}
+     * Tests we can set the keep alive with an idle time, interval and probes count on an IO {@link Socket}
      *
      * @throws IOException
      */
     @Test
-    public void testIoSocketSetKeepAliveInterval() throws IOException
+    public void testIoSocketSetKeepAlive() throws IOException
     {
         NativeSocket linSockUnderTest = new PosixSocket(socket, StandardLibStaticFactory.getStandardLib(),
                                                         new LinuxJdkFileDescriptorAccessor());
-        linSockUnderTest.setKeepAliveInterval(JodaTimeDuration.standardSeconds(1));
+
+        JodaTimeDuration idleTime = JodaTimeDuration.standardSeconds(2);
+        JodaTimeDuration interval = JodaTimeDuration.standardSeconds(1);
+        JodaTimeDuration probes = JodaTimeDuration.standardSeconds(3);
+
+        linSockUnderTest.setKeepAlive(idleTime, interval, probes);
 
         KeepAliveData keepAliveData = linSockUnderTest.getKeepAliveData();
 
+        assertEquals(2, keepAliveData.getIdleTime());
         assertEquals(1, keepAliveData.getInterval());
+        assertEquals(3, keepAliveData.getProbeCount());
     }
 
     /**
-     * Tests we can set the keep alive with a duration on an IO {@link Socket} from a
+     * Tests we can set the keep alive with an interval, idle time and probes count on an IO {@link Socket} from a
      * {@link SocketChannel}
      *
      * @throws IOException
@@ -118,28 +125,18 @@ public class PosixSocketOnLinuxTest
         NativeSocket linSockUnderTest = new PosixSocket(socketChannel.socket(),
                                                         StandardLibStaticFactory.getStandardLib(),
                                                         new LinuxJdkFileDescriptorAccessor());
-        linSockUnderTest.setKeepAliveInterval(JodaTimeDuration.standardSeconds(1));
+
+        JodaTimeDuration idleTime = JodaTimeDuration.standardSeconds(6);
+        JodaTimeDuration interval = JodaTimeDuration.standardSeconds(3);
+        JodaTimeDuration probes = JodaTimeDuration.standardSeconds(2);
+
+        linSockUnderTest.setKeepAlive(idleTime, interval, probes);
 
         KeepAliveData keepAliveData = linSockUnderTest.getKeepAliveData();
 
-        assertEquals(1, keepAliveData.getInterval());
-    }
-
-    /**
-     * Tests we can set the keep alive with a duration on an IO {@link Socket}
-     *
-     * @throws IOException
-     */
-    @Test
-    public void testIoSocketSetKeepAliveIdle() throws IOException
-    {
-        NativeSocket linSockUnderTest = new PosixSocket(socket, StandardLibStaticFactory.getStandardLib(),
-                                                        new LinuxJdkFileDescriptorAccessor());
-        linSockUnderTest.setKeepAliveIdle(JodaTimeDuration.standardSeconds(1));
-
-        KeepAliveData keepAliveData = linSockUnderTest.getKeepAliveData();
-
-        assertEquals(1, keepAliveData.getIdleTime());
+        assertEquals(6, keepAliveData.getIdleTime());
+        assertEquals(3, keepAliveData.getInterval());
+        assertEquals(2, keepAliveData.getProbeCount());
     }
 
 
@@ -172,7 +169,9 @@ public class PosixSocketOnLinuxTest
 
         assertThat(actualData.isEnabled(), is(false));
 
-        linSockUnderTest.setKeepAliveInterval(JodaTimeDuration.standardSeconds(6));
+        linSockUnderTest.setKeepAlive(JodaTimeDuration.standardSeconds(6),
+                JodaTimeDuration.standardSeconds(3),
+                JodaTimeDuration.standardSeconds(1));
         actualData = linSockUnderTest.getKeepAliveData();
 
         assertThat(actualData.isEnabled(), is(true));
@@ -190,7 +189,9 @@ public class PosixSocketOnLinuxTest
         NativeSocket linSockUnderTest = new PosixSocket(socket, mockStdLib, new LinuxJdkFileDescriptorAccessor());
         when(mockPosixSocketLib.setsockopt(anyInt(), anyInt(), anyInt(), any(Pointer.class), anyInt())).thenReturn(-1);
 
-        linSockUnderTest.setKeepAliveIdle(JodaTimeDuration.standardSeconds(3));
+        linSockUnderTest.setKeepAlive(JodaTimeDuration.standardSeconds(6),
+                JodaTimeDuration.standardSeconds(3),
+                JodaTimeDuration.standardSeconds(1));
     }
 
 

--- a/src/test/java/org/mjd/nativesocket/internal/PosixSocketOnLinuxTest.java
+++ b/src/test/java/org/mjd/nativesocket/internal/PosixSocketOnLinuxTest.java
@@ -120,9 +120,9 @@ public class PosixSocketOnLinuxTest
      * @throws IOException
      */
     @Test
-    public void testNioSocketSetKeepAliveInterval() throws IOException
+    public void testNioSocketChannelSetKeepAlive() throws IOException
     {
-        NativeSocket linSockUnderTest = new PosixSocket(socketChannel.socket(),
+        NativeSocket linSockUnderTest = new PosixSocket(socketChannel,
                                                         StandardLibStaticFactory.getStandardLib(),
                                                         new LinuxJdkFileDescriptorAccessor());
 
@@ -141,7 +141,7 @@ public class PosixSocketOnLinuxTest
 
 
     /**
-     * Tests get keep alive data without previously setting it.
+     * Tests get keep alive data for {@link Socket} without previously setting it.
      *
      * @throws IOException
      */
@@ -150,6 +150,25 @@ public class PosixSocketOnLinuxTest
     {
         NativeSocket linSockUnderTest = new PosixSocket(socket, StandardLibStaticFactory.getStandardLib(),
                                                         new LinuxJdkFileDescriptorAccessor());
+
+        KeepAliveData actualData = linSockUnderTest.getKeepAliveData();
+
+        assertEquals(systemInterval, actualData.getInterval());
+        assertEquals(systemIdleTime, actualData.getIdleTime());
+        assertEquals(systemProbeCount, actualData.getProbeCount());
+        assertThat(actualData.isEnabled(), is(false));
+    }
+
+    /**
+     * Tests get keep alive data for {@link SocketChannel} without previously setting it.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testNioSocketChannelGetKeepAliveData() throws IOException
+    {
+        NativeSocket linSockUnderTest = new PosixSocket(socketChannel, StandardLibStaticFactory.getStandardLib(),
+                new LinuxJdkFileDescriptorAccessor());
 
         KeepAliveData actualData = linSockUnderTest.getKeepAliveData();
 


### PR DESCRIPTION
1. Changed the NativeSocket interface to support setting the keep alive parameters (idle time, interval and probes) in one method.
2. Refactored code to enable keep alive settings for the NIO SocketChannel, since the previous implementation was not functional. 